### PR TITLE
remove project resources table from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,16 +74,6 @@ More Open Source and usage information can be found here:
 * [GOVERNANCE.md](./GOVERNANCE.md)
 * [LICENSE](./LICENSE)
 
-## Project Resources
-
-| Resource                                                                              | Description                                                                   |
-|---------------------------------------------------------------------------------------|-------------------------------------------------------------------------------|
-| [CODEOWNERS](./CODEOWNERS)                                                            | Outlines the project lead(s)                                                  |
-| [CODE_OF_CONDUCT.md](https://github.com/block/.github/blob/main/CODE_OF_CONDUCT.md)   | Expected behavior for project contributors, promoting a welcoming environment |
-| [CONTRIBUTING.md](https://github.com/block/.github/blob/main/CONTRIBUTING.md)         | Developer guide to build, test, run, access CI, chat, discuss, file issues    |
-| [GOVERNANCE.md](./GOVERNANCE.md)                                                      | Project governance                                                            |
-| [LICENSE](./LICENSE)                                                                  | Apache License, Version 2.0                                                   |
-
 Authors:
 * Tyler Zupan
 * Josh Hamet


### PR DESCRIPTION
These are mostly dead links that should have been removed from the template.